### PR TITLE
kjgorman/simple metrics exposure

### DIFF
--- a/error_budget_test.go
+++ b/error_budget_test.go
@@ -1,7 +1,7 @@
 package hostpool
 
 import (
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 
 	"testing"
 	"time"

--- a/hostpool.go
+++ b/hostpool.go
@@ -3,12 +3,6 @@
 // avoided. A good overview of Epsilon Greedy is here http://stevehanov.ca/blog/index.php?id=132
 package hostpool
 
-import (
-	"log"
-	"sync"
-	"time"
-)
-
 // Returns current version
 func Version() string {
 	return "0.1"
@@ -23,13 +17,8 @@ func Version() string {
 type HostPoolResponse interface {
 	Host() string
 	Mark(error)
-	hostPool() HostPool
-}
 
-type standardHostPoolResponse struct {
-	host string
-	sync.Once
-	pool HostPool
+	hostPool() HostPool
 }
 
 // --- HostPool structs and interfaces ----
@@ -38,269 +27,40 @@ type standardHostPoolResponse struct {
 // allow you to Get a HostPoolResponse (which includes a hostname to use),
 // get the list of all Hosts, and use ResetAll to reset state.
 type HostPool interface {
+	// Get selects a host from the pool. The returned response should then be marked as
+	// either successful or failed when the host is used (by calling Mark() on the response
+	// with the error value either nil for success, or set for failure).
 	Get() HostPoolResponse
-	// keep the marks separate so we can override independently
-	markSuccess(HostPoolResponse)
-	markFailed(HostPoolResponse)
 
+	// ResetAll marks all hosts in the pool as alive
 	ResetAll()
+
 	// ReturnUnhealthy when called with true will prevent an unhealthy node from
 	// being returned and will instead return a nil HostPoolResponse. If using
 	// this feature then you should check the result of Get for nil
 	ReturnUnhealthy(v bool)
+
+	// Hosts returns the current set of hosts known to the host pool
 	Hosts() []string
+
+	// SetHosts sets the current set of hosts known to the host pool. The set hosts default
+	// to being alive
 	SetHosts([]string)
+
+	// Statistics returns a sample of properties of the hostpool that would be useful
+	// to monitor, for example, the number of hosts, and the number of alive hosts
+	Statistics() HostPoolStatistics
 
 	// Close the hostpool and release all resources.
 	Close()
+
+	// keep the marks separate so we can override independently
+	markSuccess(HostPoolResponse)
+	markFailed(HostPoolResponse)
 }
 
-type standardHostPool struct {
-	sync.RWMutex
-	hosts           map[string]*hostEntry
-	hostList        []*hostEntry
-	returnUnhealthy bool
-	nextHostIndex   int
-	// Host retry parameters
-	initialRetryDelay time.Duration
-	maxRetryInterval  time.Duration
-	// Error budget config
-	maxFailures   int
-	failureWindow time.Duration
-}
-
-type StandardHostPoolOptions struct {
-	// Host retry parameters
-	InitialRetryDelay time.Duration
-	MaxRetryInterval  time.Duration
-	// Error budget config
-	MaxFailures   int
-	FailureWindow time.Duration
-}
-
-// ------ constants -------------------
-
-const initialRetryDelay = time.Duration(30) * time.Second
-const maxRetryInterval = time.Duration(900) * time.Second
-const defaultFailureWindow = time.Duration(60) * time.Second
-
-// Construct a basic HostPool using the hostnames provided
-func New(hosts []string) HostPool {
-	p := &standardHostPool{
-		returnUnhealthy:   true,
-		hosts:             make(map[string]*hostEntry, len(hosts)),
-		hostList:          make([]*hostEntry, len(hosts)),
-		initialRetryDelay: initialRetryDelay,
-		maxRetryInterval:  maxRetryInterval,
-	}
-
-	for i, h := range hosts {
-		e := &hostEntry{
-			host:       h,
-			retryDelay: p.initialRetryDelay,
-		}
-		p.hosts[h] = e
-		p.hostList[i] = e
-	}
-
-	return p
-}
-
-func NewWithOptions(hosts []string, options StandardHostPoolOptions) HostPool {
-	// Initialise with defaults, override from options
-	p := &standardHostPool{
-		returnUnhealthy:   true,
-		hosts:             make(map[string]*hostEntry, len(hosts)),
-		hostList:          make([]*hostEntry, len(hosts)),
-		initialRetryDelay: initialRetryDelay,
-		maxRetryInterval:  maxRetryInterval,
-		failureWindow:     defaultFailureWindow,
-	}
-
-	if options.InitialRetryDelay > 0 {
-		p.initialRetryDelay = options.InitialRetryDelay
-	}
-	if options.MaxRetryInterval > 0 {
-		p.maxRetryInterval = options.MaxRetryInterval
-	}
-	if options.MaxFailures > 0 {
-		p.maxFailures = options.MaxFailures
-	}
-	if options.FailureWindow > 0 {
-		p.failureWindow = options.FailureWindow
-	}
-
-	for i, h := range hosts {
-		e := &hostEntry{
-			host:       h,
-			retryDelay: p.initialRetryDelay,
-		}
-		if p.maxFailures > 0 {
-			// We test for failures > maxFailures, so need an extra slot in the buffer.
-			e.failures = NewRingBuffer(p.maxFailures + 1)
-		}
-		p.hosts[h] = e
-		p.hostList[i] = e
-	}
-
-	return p
-}
-
-func (r *standardHostPoolResponse) Host() string {
-	return r.host
-}
-
-func (r *standardHostPoolResponse) hostPool() HostPool {
-	return r.pool
-}
-
-func (r *standardHostPoolResponse) Mark(err error) {
-	r.Do(func() {
-		doMark(err, r)
-	})
-}
-
-func doMark(err error, r HostPoolResponse) {
-	if err == nil {
-		r.hostPool().markSuccess(r)
-	} else {
-		r.hostPool().markFailed(r)
-	}
-}
-
-// return an entry from the HostPool
-func (p *standardHostPool) Get() HostPoolResponse {
-	p.Lock()
-	defer p.Unlock()
-	host := p.getRoundRobin()
-	if host == "" {
-		return nil
-	}
-
-	return &standardHostPoolResponse{host: host, pool: p}
-}
-
-func (p *standardHostPool) getRoundRobin() string {
-	now := time.Now()
-	hostCount := len(p.hostList)
-	for i := range p.hostList {
-		// iterate via sequenece from where we last iterated
-		currentIndex := (i + p.nextHostIndex) % hostCount
-
-		h := p.hostList[currentIndex]
-		if !h.dead {
-			p.nextHostIndex = currentIndex + 1
-			return h.host
-		}
-		if h.nextRetry.Before(now) {
-			h.willRetryHost(p.maxRetryInterval)
-			p.nextHostIndex = currentIndex + 1
-			return h.host
-		}
-	}
-
-	// all hosts are down and returnUnhealhy is false then return no host
-	if !p.returnUnhealthy {
-		return ""
-	}
-
-	// all hosts are down. re-add them
-	p.doResetAll()
-	p.nextHostIndex = 0
-	return p.hostList[0].host
-}
-
-func (p *standardHostPool) ResetAll() {
-	p.Lock()
-	defer p.Unlock()
-	p.doResetAll()
-}
-
-func (p *standardHostPool) SetHosts(hosts []string) {
-	p.Lock()
-	defer p.Unlock()
-	p.setHosts(hosts)
-}
-
-func (p *standardHostPool) ReturnUnhealthy(v bool) {
-	p.Lock()
-	defer p.Unlock()
-	p.returnUnhealthy = v
-}
-
-func (p *standardHostPool) setHosts(hosts []string) {
-	p.hosts = make(map[string]*hostEntry, len(hosts))
-	p.hostList = make([]*hostEntry, len(hosts))
-
-	for i, h := range hosts {
-		e := &hostEntry{
-			host:       h,
-			retryDelay: p.initialRetryDelay,
-		}
-		if p.maxFailures > 0 {
-			// We test for failures > maxFailures, so need an extra slot in the buffer.
-			e.failures = NewRingBuffer(p.maxFailures + 1)
-		}
-		p.hosts[h] = e
-		p.hostList[i] = e
-	}
-}
-
-// this actually performs the logic to reset,
-// and should only be called when the lock has
-// already been acquired
-func (p *standardHostPool) doResetAll() {
-	for _, h := range p.hosts {
-		h.dead = false
-	}
-}
-
-func (p *standardHostPool) Close() {
-	for _, h := range p.hosts {
-		h.dead = true
-	}
-}
-
-func (p *standardHostPool) markSuccess(hostR HostPoolResponse) {
-	host := hostR.Host()
-	p.Lock()
-	defer p.Unlock()
-
-	h, ok := p.hosts[host]
-	if !ok {
-		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
-	}
-	h.dead = false
-}
-
-func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
-	host := hostR.Host()
-	p.Lock()
-	defer p.Unlock()
-
-	h, ok := p.hosts[host]
-	if !ok {
-		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
-	}
-	if !h.dead {
-		if h.failures != nil {
-			ts := time.Now()
-			h.failures.insert(ts)
-			if h.failures.since(ts.Add(-p.failureWindow)) > p.maxFailures {
-				log.Printf("host %s exceeded %d failures in %s", h.host, p.maxFailures, p.failureWindow)
-				h.markDead(p.initialRetryDelay)
-			}
-		} else {
-			h.markDead(p.initialRetryDelay)
-		}
-	}
-
-}
-
-func (p *standardHostPool) Hosts() []string {
-	hosts := make([]string, 0, len(p.hosts))
-	for host := range p.hosts {
-		hosts = append(hosts, host)
-	}
-	return hosts
+// HostPoolStatistics represents a single sample of possible statistics associated
+// with a hostpool
+type HostPoolStatistics struct {
+	Gauges []Gauge
 }

--- a/hostpool_test.go
+++ b/hostpool_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHostPool(t *testing.T) {
@@ -182,7 +182,7 @@ func TestHostPoolErrorBudget(t *testing.T) {
 	dummyErr := errors.New("Dummy Error")
 
 	p := NewWithOptions([]string{"a", "b"}, StandardHostPoolOptions{
-		MaxFailures: 2,
+		MaxFailures:   2,
 		FailureWindow: 60 * time.Second,
 	})
 
@@ -219,8 +219,8 @@ func TestHostPoolErrorBudgetReset(t *testing.T) {
 	dummyErr := errors.New("Dummy Error")
 
 	p := NewWithOptions([]string{"a", "b"}, StandardHostPoolOptions{
-		MaxFailures:       1,
-		FailureWindow:     1 * time.Second,
+		MaxFailures:   1,
+		FailureWindow: 1 * time.Second,
 	})
 
 	// Initially both hosts are available

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,14 @@
+package hostpool
+
+// A gauge is a metric which represents a single value, whose value
+// may increase or decrease. A hostpool specific example could be
+// the number of hosts in the pool.
+type Gauge struct {
+	Name  string
+	Value int64
+}
+
+const (
+	HostPoolGaugeNumberOfHosts     = "hostpool_number_of_hosts"
+	HostPoolGaugeNumberOfLiveHosts = "hostpool_number_of_live_hosts"
+)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,35 @@
+package hostpool
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsBasics(t *testing.T) {
+	pool := New([]string{"a", "b", "c"})
+
+	stats := pool.Statistics()
+
+	gaugeWithName := func(name string) Gauge {
+		for _, gauge := range stats.Gauges {
+			if gauge.Name == name {
+				return gauge
+			}
+		}
+
+		require.FailNow(t, "Couldn't find named gauge", "Wanted %s but had %v", name, stats.Gauges)
+		return Gauge{} //unreachable
+	}
+
+	require.Equal(t, int64(3), gaugeWithName(HostPoolGaugeNumberOfHosts).Value)
+	require.Equal(t, int64(3), gaugeWithName(HostPoolGaugeNumberOfLiveHosts).Value)
+
+	poolMember := pool.Get()
+	poolMember.Mark(errors.New("any old error"))
+
+	stats = pool.Statistics()
+	require.Equal(t, int64(3), gaugeWithName(HostPoolGaugeNumberOfHosts).Value)
+	require.Equal(t, int64(2), gaugeWithName(HostPoolGaugeNumberOfLiveHosts).Value)
+}

--- a/standard_hostpool.go
+++ b/standard_hostpool.go
@@ -1,0 +1,290 @@
+package hostpool
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// standardHostPoolResponse implements HostPoolResponse
+type standardHostPoolResponse struct {
+	host string
+	sync.Once
+	pool HostPool
+}
+
+func (r *standardHostPoolResponse) Host() string {
+	return r.host
+}
+
+func (r *standardHostPoolResponse) hostPool() HostPool {
+	return r.pool
+}
+
+func (r *standardHostPoolResponse) Mark(err error) {
+	r.Do(func() {
+		doMark(err, r)
+	})
+}
+
+func doMark(err error, r HostPoolResponse) {
+	if err == nil {
+		r.hostPool().markSuccess(r)
+	} else {
+		r.hostPool().markFailed(r)
+	}
+}
+
+// standardHostPool implements HostPool
+type standardHostPool struct {
+	sync.RWMutex
+	hosts           map[string]*hostEntry
+	hostList        []*hostEntry
+	returnUnhealthy bool
+	nextHostIndex   int
+	// Host retry parameters
+	initialRetryDelay time.Duration
+	maxRetryInterval  time.Duration
+	// Error budget config
+	maxFailures   int
+	failureWindow time.Duration
+}
+
+type StandardHostPoolOptions struct {
+	// Host retry parameters
+	InitialRetryDelay time.Duration
+	MaxRetryInterval  time.Duration
+	// Error budget config
+	MaxFailures   int
+	FailureWindow time.Duration
+}
+
+// ------ constants -------------------
+
+const initialRetryDelay = time.Duration(30) * time.Second
+const maxRetryInterval = time.Duration(900) * time.Second
+const defaultFailureWindow = time.Duration(60) * time.Second
+
+// Construct a basic HostPool using the hostnames provided
+func New(hosts []string) HostPool {
+	p := &standardHostPool{
+		returnUnhealthy:   true,
+		hosts:             make(map[string]*hostEntry, len(hosts)),
+		hostList:          make([]*hostEntry, len(hosts)),
+		initialRetryDelay: initialRetryDelay,
+		maxRetryInterval:  maxRetryInterval,
+	}
+
+	for i, h := range hosts {
+		e := &hostEntry{
+			host:       h,
+			retryDelay: p.initialRetryDelay,
+		}
+		p.hosts[h] = e
+		p.hostList[i] = e
+	}
+
+	return p
+}
+
+func NewWithOptions(hosts []string, options StandardHostPoolOptions) HostPool {
+	// Initialise with defaults, override from options
+	p := &standardHostPool{
+		returnUnhealthy:   true,
+		hosts:             make(map[string]*hostEntry, len(hosts)),
+		hostList:          make([]*hostEntry, len(hosts)),
+		initialRetryDelay: initialRetryDelay,
+		maxRetryInterval:  maxRetryInterval,
+		failureWindow:     defaultFailureWindow,
+	}
+
+	if options.InitialRetryDelay > 0 {
+		p.initialRetryDelay = options.InitialRetryDelay
+	}
+	if options.MaxRetryInterval > 0 {
+		p.maxRetryInterval = options.MaxRetryInterval
+	}
+	if options.MaxFailures > 0 {
+		p.maxFailures = options.MaxFailures
+	}
+	if options.FailureWindow > 0 {
+		p.failureWindow = options.FailureWindow
+	}
+
+	for i, h := range hosts {
+		e := &hostEntry{
+			host:       h,
+			retryDelay: p.initialRetryDelay,
+		}
+		if p.maxFailures > 0 {
+			// We test for failures > maxFailures, so need an extra slot in the buffer.
+			e.failures = NewRingBuffer(p.maxFailures + 1)
+		}
+		p.hosts[h] = e
+		p.hostList[i] = e
+	}
+
+	return p
+}
+
+// return an entry from the HostPool
+func (p *standardHostPool) Get() HostPoolResponse {
+	p.Lock()
+	defer p.Unlock()
+	host := p.getRoundRobin()
+	if host == "" {
+		return nil
+	}
+
+	return &standardHostPoolResponse{host: host, pool: p}
+}
+
+func (p *standardHostPool) getRoundRobin() string {
+	now := time.Now()
+	hostCount := len(p.hostList)
+	for i := range p.hostList {
+		// iterate via sequenece from where we last iterated
+		currentIndex := (i + p.nextHostIndex) % hostCount
+
+		h := p.hostList[currentIndex]
+		if !h.dead {
+			p.nextHostIndex = currentIndex + 1
+			return h.host
+		}
+		if h.nextRetry.Before(now) {
+			h.willRetryHost(p.maxRetryInterval)
+			p.nextHostIndex = currentIndex + 1
+			return h.host
+		}
+	}
+
+	// all hosts are down and returnUnhealhy is false then return no host
+	if !p.returnUnhealthy {
+		return ""
+	}
+
+	// all hosts are down. re-add them
+	p.doResetAll()
+	p.nextHostIndex = 0
+	return p.hostList[0].host
+}
+
+func (p *standardHostPool) ResetAll() {
+	p.Lock()
+	defer p.Unlock()
+	p.doResetAll()
+}
+
+func (p *standardHostPool) SetHosts(hosts []string) {
+	p.Lock()
+	defer p.Unlock()
+	p.setHosts(hosts)
+}
+
+func (p *standardHostPool) ReturnUnhealthy(v bool) {
+	p.Lock()
+	defer p.Unlock()
+	p.returnUnhealthy = v
+}
+
+func (p *standardHostPool) setHosts(hosts []string) {
+	p.hosts = make(map[string]*hostEntry, len(hosts))
+	p.hostList = make([]*hostEntry, len(hosts))
+
+	for i, h := range hosts {
+		e := &hostEntry{
+			host:       h,
+			retryDelay: p.initialRetryDelay,
+		}
+		if p.maxFailures > 0 {
+			// We test for failures > maxFailures, so need an extra slot in the buffer.
+			e.failures = NewRingBuffer(p.maxFailures + 1)
+		}
+		p.hosts[h] = e
+		p.hostList[i] = e
+	}
+}
+
+// this actually performs the logic to reset,
+// and should only be called when the lock has
+// already been acquired
+func (p *standardHostPool) doResetAll() {
+	for _, h := range p.hosts {
+		h.dead = false
+	}
+}
+
+func (p *standardHostPool) Close() {
+	for _, h := range p.hosts {
+		h.dead = true
+	}
+}
+
+func (p *standardHostPool) markSuccess(hostR HostPoolResponse) {
+	host := hostR.Host()
+	p.Lock()
+	defer p.Unlock()
+
+	h, ok := p.hosts[host]
+	if !ok {
+		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
+	}
+	h.dead = false
+}
+
+func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
+	host := hostR.Host()
+	p.Lock()
+	defer p.Unlock()
+
+	h, ok := p.hosts[host]
+	if !ok {
+		log.Fatalf("host %s not in HostPool %v", host, p.Hosts())
+	}
+	if !h.dead {
+		if h.failures != nil {
+			ts := time.Now()
+			h.failures.insert(ts)
+			if h.failures.since(ts.Add(-p.failureWindow)) > p.maxFailures {
+				log.Printf("host %s exceeded %d failures in %s", h.host, p.maxFailures, p.failureWindow)
+				h.markDead(p.initialRetryDelay)
+			}
+		} else {
+			h.markDead(p.initialRetryDelay)
+		}
+	}
+
+}
+
+func (p *standardHostPool) Hosts() []string {
+	hosts := make([]string, 0, len(p.hosts))
+	for host := range p.hosts {
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func (p *standardHostPool) Statistics() HostPoolStatistics {
+	p.RLock()
+	defer p.RUnlock()
+
+	var alive int64 = 0
+	for _, host := range p.hosts {
+		if !host.dead {
+			alive += 1
+		}
+	}
+
+	return HostPoolStatistics{
+		Gauges: []Gauge{
+			{
+				Name:  HostPoolGaugeNumberOfHosts,
+				Value: int64(len(p.hosts)),
+			},
+			{
+				Name:  HostPoolGaugeNumberOfLiveHosts,
+				Value: alive,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Allows a user to see some small details of the internal state of the pool, i.e.
how many hosts are currently down.

From a design perspective, it could potentially be argued that exposing these
_as metrics_ is too opinionated (e.g. we could just expose the host details 
somehow and allow the client to count the live ones)—however using a common
generic struct like `Gauge` means that specific implementations can map 
their internal state onto these exported structs without needing to expose their
implementation (which might be desirable?).

Split out the standard host pool implementation to its own file to make the
hostpool interface more obvious as well.