### PR TITLE
Pre-calculate all non-active buckets in Epsilon Greedy Pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
-  - tip
+  - 1.15.x
+  - 1.16.x
 
 script: go test -v -benchmem -run=".*" ./... -bench "Benchmark.*"

--- a/epsilon_greedy.go
+++ b/epsilon_greedy.go
@@ -116,19 +116,20 @@ func (p *epsilonGreedyHostPool) performEpsilonGreedyDecay() {
 func (p *epsilonGreedyHostPool) Get() HostPoolResponse {
 	p.Lock()
 	defer p.Unlock()
-	host := p.getEpsilonGreedy()
+
+	now := time.Now()
+	host := p.getEpsilonGreedy(now)
 	if host == "" {
 		return nil
 	}
 
-	started := time.Now()
 	return &epsilonHostPoolResponse{
 		standardHostPoolResponse: standardHostPoolResponse{host: host, pool: p},
-		started:                  started,
+		started:                  now,
 	}
 }
 
-func (p *epsilonGreedyHostPool) getEpsilonGreedy() string {
+func (p *epsilonGreedyHostPool) getEpsilonGreedy(now time.Time) string {
 	var hostToUse *hostEntry
 
 	// this is our exploration phase
@@ -147,7 +148,6 @@ func (p *epsilonGreedyHostPool) getEpsilonGreedy() string {
 		candidateScores       = make([]float64, 0, 256)
 	)
 
-	now := time.Now()
 	for _, h := range p.hostList {
 		if !h.canTryHost(now) {
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/bitly/go-hostpool
+
+go 1.15
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/host_entry.go
+++ b/host_entry.go
@@ -59,14 +59,17 @@ func (h *hostEntry) getWeightedAverageResponseTime() float64 {
 
 func (h *hostEntry) epsilonDecay() {
 	// Move to the next position in the ring
-	buckets := len(h.epsilonCounts)
-	h.epsilonIndex = (h.epsilonIndex + 1) % buckets
+	h.epsilonIndex = (h.epsilonIndex + 1) % len(h.epsilonCounts)
 	h.epsilonCounts[h.epsilonIndex] = 0
 	h.epsilonValues[h.epsilonIndex] = 0
+	h.calculateWeightedAverages()
+}
 
+func (h *hostEntry) calculateWeightedAverages() {
 	// We start with the oldest entry in the ring and move forward, coming up to
 	// the most recent entry (but not the current one which is when i = 0
 	// resulting in pos pointing to the current bucket index)
+	buckets := len(h.epsilonCounts)
 	var total, lastValue float64
 	for i := 1; i < buckets; i++ {
 		pos := (h.epsilonIndex + i) % buckets

--- a/host_entry.go
+++ b/host_entry.go
@@ -7,17 +7,18 @@ import (
 // --- hostEntry - this is due to get upgraded
 
 type hostEntry struct {
-	host              string
-	nextRetry         time.Time
-	retryCount        int16
-	retryDelay        time.Duration
-	dead              bool
-	epsilonCounts     []int64
-	epsilonValues     []int64
-	epsilonIndex      int
-	epsilonValue      float64
-	epsilonPercentage float64
-	failures          *ringBuffer
+	host       string
+	nextRetry  time.Time
+	retryCount int16
+	retryDelay time.Duration
+	dead       bool
+	failures   *ringBuffer
+
+	epsilonCounts          []int64 // ring of counts observed
+	epsilonValues          []int64 // ring of total time observations observed
+	epsilonIndex           int     // current index in the ring
+	epsilonWeightedTotal   float64 // The total not including the active bucket
+	epsilonWeightedLastVal float64 // The last non-zero count average
 }
 
 func (h *hostEntry) canTryHost(now time.Time) bool {
@@ -42,25 +43,49 @@ func (h *hostEntry) willRetryHost(maxRetryInterval time.Duration) {
 }
 
 func (h *hostEntry) getWeightedAverageResponseTime() float64 {
-	var value float64
-	var lastValue float64
+	currentBucketCount := h.epsilonCounts[h.epsilonIndex]
 
-	// start at 1 so we start with the oldest entry
+	// If we've not seen any observations yet, use the last value from the
+	// previous buckets
+	if currentBucketCount == 0 {
+		return h.epsilonWeightedTotal + h.epsilonWeightedLastVal
+	}
+
+	// Take our weighted total and add on the average of our current index
+	// which has a 100% weighting
+	currentAvg := float64(h.epsilonValues[h.epsilonIndex]) / float64(currentBucketCount)
+	return h.epsilonWeightedTotal + currentAvg
+}
+
+func (h *hostEntry) epsilonDecay() {
+	// Move to the next position in the ring
 	buckets := len(h.epsilonCounts)
-	for i := 1; i <= buckets; i += 1 {
+	h.epsilonIndex = (h.epsilonIndex + 1) % buckets
+	h.epsilonCounts[h.epsilonIndex] = 0
+	h.epsilonValues[h.epsilonIndex] = 0
+
+	// We start with the oldest entry in the ring and move forward, coming up to
+	// the most recent entry (but not the current one which is when i = 0
+	// resulting in pos pointing to the current bucket index)
+	var total, lastValue float64
+	for i := 1; i < buckets; i++ {
 		pos := (h.epsilonIndex + i) % buckets
 		bucketCount := h.epsilonCounts[pos]
-		// Changing the line below to what I think it should be to get the weights right
 		weight := float64(i) / float64(buckets)
-		if bucketCount > 0 {
-			currentValue := float64(h.epsilonValues[pos]) / float64(bucketCount)
-			value += currentValue * weight
-			lastValue = currentValue
+		if h.epsilonCounts[pos] > 0 {
+			// We have observed values in this bucket, so let's tally them up
+			avg := float64(h.epsilonValues[pos]) / float64(bucketCount)
+			total += avg * weight
+			lastValue = avg
 		} else {
-			value += lastValue * weight
+			// We had no values observed in this bucket, so we just use the
+			// previous bucket and carry over the weight
+			total += lastValue * weight
 		}
 	}
-	return value
+
+	h.epsilonWeightedTotal = total
+	h.epsilonWeightedLastVal = lastValue
 }
 
 func (h *hostEntry) markDead(initialRetryDelay time.Duration) {

--- a/host_entry_test.go
+++ b/host_entry_test.go
@@ -1,0 +1,92 @@
+package hostpool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWeightedAverageResponseTime(t *testing.T) {
+	t.Parallel()
+
+	tcs := [...]struct {
+		name 	 string
+		entry 	 *hostEntry
+		expected float64
+	}{
+		{
+			name: "zero case",
+			entry: &hostEntry{
+				epsilonCounts: []int64{0},
+				epsilonValues: []int64{0},
+				epsilonIndex:  0,
+			},
+
+			expected: float64(0),
+		},
+		{
+			name: "simple example",
+			entry: &hostEntry{
+				// this field tracks the number of observations in each bucket
+				epsilonCounts: []int64{1, 1, 1, 0, 0},
+				// this field tracks the sum of response times in each bucket
+				epsilonValues: []int64{1000, 1000, 1000, 0, 0},
+				// this field tracks how far through the buckets we are
+				epsilonIndex: 2,
+			},
+
+			// 5 buckets, so weights step by 0.2 each time
+			// 1000 * 0.6 + 1000 * 0.8 + 1000 * 1
+			// 600 + 800 + 1000
+			expected: float64(2400),
+		},
+		{
+			name: "simple example showing iteration order",
+			entry: &hostEntry{
+				epsilonCounts: []int64{1, 1, 1, 0, 0},
+				epsilonValues: []int64{2000, 1000, 500, 0, 0},
+				epsilonIndex:  2,
+			},
+
+			// 5 buckets, so weights step by 0.2 each time
+			// 2000 * 0.6 + 1000 * 0.8 + 500 * 1
+			// 1200 + 800 + 500
+			expected: float64(2500),
+		},
+		{
+			name: "another example showing the count + sum are averaged first",
+			entry: &hostEntry{
+				epsilonCounts: []int64{2, 4, 5, 5, 5},
+				epsilonValues: []int64{2000, 1000, 500, 250, 125},
+				epsilonIndex:  4, // newest value in index 4
+			},
+
+			// (2000 / 2) * 0.2 + (1000 / 4) * 0.4 + (500 / 5) * 0.6 + (250 / 5) * 0.8 + (125 / 5) * 1
+			// 1000 * 0.2 + 250 * 0.4 + 100 * 0.6 + 50 * 0.8 + 25 * 1
+			// 200 + 100 + 60 + 40 + 25
+			expected: float64(425),
+		},
+		{
+			name: "if one bucket has no entries, we take the previous value",
+			entry: &hostEntry{
+				epsilonCounts: []int64{2, 4, 5, 0, 5},
+				epsilonValues: []int64{2000, 1000, 500, 0, 125},
+				epsilonIndex:  4, // newest value in index 4
+			},
+
+			// (2000 / 2) * 0.2 + (1000 / 4) * 0.4 + (500 / 5) * 0.6 + <empty bucket>  + (125 / 5) * 1
+			//                                uses previous value 👉 + (500 / 5) * 0.8 +
+			// 1000 * 0.2 + 250 * 0.4 + 100 * 0.6 + (100 * 0.8 + 25 * 1
+			//                                             ☝️ weight still steps down
+			// 200 + 100 + 60 + 80 + 25
+			expected: float64(465),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.entry.calculateWeightedAverages()
+			require.Equal(t, tc.expected, tc.entry.getWeightedAverageResponseTime())
+		})
+	}
+}

--- a/hostpool_test.go
+++ b/hostpool_test.go
@@ -147,7 +147,7 @@ func BenchmarkEpsilonGreedy(b *testing.B) {
 }
 
 func BenchmarkEpsilonGreedyManyHosts(topB *testing.B) {
-	bench := func(hostCount int) func(*testing.B) {
+	bench := func(hostCount int, enableDecay bool) func(*testing.B) {
 		return func(b *testing.B) {
 			b.StopTimer()
 
@@ -167,7 +167,7 @@ func BenchmarkEpsilonGreedyManyHosts(topB *testing.B) {
 
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {
-				if i != 0 && i%100 == 0 {
+				if enableDecay && i != 0 && i%100 == 0 {
 					p.performEpsilonGreedyDecay()
 				}
 				hostR := p.Get()
@@ -177,11 +177,17 @@ func BenchmarkEpsilonGreedyManyHosts(topB *testing.B) {
 		}
 	}
 
-	topB.Run("Hosts10", bench(10))
-	topB.Run("Hosts25", bench(25))
-	topB.Run("Hosts50", bench(50))
-	topB.Run("Hosts100", bench(100))
-	topB.Run("Hosts250", bench(250))
+	topB.Run("Hosts10/NoDecay", bench(10, false))
+	topB.Run("Hosts25/NoDecay", bench(25, false))
+	topB.Run("Hosts50/NoDecay", bench(50, false))
+	topB.Run("Hosts100/NoDecay", bench(100, false))
+	topB.Run("Hosts250/NoDecay", bench(250, false))
+
+	topB.Run("Hosts10/WithDecay", bench(10, true))
+	topB.Run("Hosts25/WithDecay", bench(25, true))
+	topB.Run("Hosts50/WithDecay", bench(50, true))
+	topB.Run("Hosts100/WithDecay", bench(100, true))
+	topB.Run("Hosts250/WithDecay", bench(250, true))
 }
 
 func TestHostPoolErrorBudget(t *testing.T) {


### PR DESCRIPTION
This PR makes some substantial performance improvements to the Epsilon Greedy Hostpool.

Before I explain the performance improvements, I need to explain a little about how the scoring calculation works per host. Let's take an example of a host with 5 stored buckets. The pool keeps track of two core values per bucket, a count and a cumulative duration total (in nanoseconds). 

The goal is to keep track of performance over time but also weigh real time performance higher when scoring.

The list of buckets is a fixed size ring buffer, here we use 5 (but in practice go-hostpool uses 120 buckets). 
- Each bucket has an proportionally reduced weighting depending on how old it is (so older buckets have a reduced weighting, more recent buckets have an increased weighting). 
- The current bucket has a 100% weighting to the score (as it is the most recent values)

![image](https://user-images.githubusercontent.com/76773/109498846-f4bcf880-7a8b-11eb-80ba-78ee5be81d45.png)

So in the example above, the score for this particular host will be calculated as (starting from the oldest bucket)
```
      6 ×  540 × (1 / 5.0)
  +  15 × 1495 × (2 / 5.0)
  +  11 ×  900 × (3 / 5.0)
  +  10 × 1500 × (4 / 5.0)
  +  12 × 1140 × (5 / 5.0)
```

When decay happens, the current bucket and oldest bucket offsets move one index forward, resetting the current bucket to zero.

After some profiling, I found this calculation to be taking a substantial part of CPU time and was being done _every time we requested a host_. I found that this entire calculation could be optimised substantially to pre-calculate most of it. Only the average of the current bucket is changing in this calculation. We can precompute all the other bucket totals and just add the current bucket average on demand

![image](https://user-images.githubusercontent.com/76773/109500075-a7418b00-7a8d-11eb-88f6-ffdb5d7af1ce.png)

This means on each decay, we pre-compute the following sum one time on decay and essentially 'cache' it
```
      6 ×  540 × (1 / 5.0)
  +  15 × 1495 × (2 / 5.0)
  +  11 ×  900 × (3 / 5.0)
  +  10 × 1500 × (4 / 5.0)
```

Then when we request the current score of the host, we take the current bucket average (which is weighted at 100% anyway) and add it on, thus saving four other calculations in this example (and 119 per host in real life).

Before these changes, here's how the performance stacked up
```
pkg: github.com/bitly/go-hostpool
BenchmarkEpsilonGreedy
BenchmarkEpsilonGreedy-8            	  449230	      2820 ns/op	     127 B/op	       3 allocs/op
BenchmarkEpsilonGreedyManyHosts
BenchmarkEpsilonGreedyManyHosts/Hosts10
BenchmarkEpsilonGreedyManyHosts/Hosts10-8         	  105246	     12184 ns/op	     349 B/op	       6 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts25
BenchmarkEpsilonGreedyManyHosts/Hosts25-8         	   42470	     29409 ns/op	     601 B/op	       7 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts50
BenchmarkEpsilonGreedyManyHosts/Hosts50-8         	   21153	     59977 ns/op	    1070 B/op	       8 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts100
BenchmarkEpsilonGreedyManyHosts/Hosts100-8        	   10000	    114046 ns/op	    1663 B/op	       9 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts250
BenchmarkEpsilonGreedyManyHosts/Hosts250-8        	    5290	    268156 ns/op	    1047 B/op	       8 allocs/op
```

This meant if you have 100 hosts, you'll be burning 114046 nanoseconds of CPU time (under a mutual lock also) fetching a host. That's a very long amount of time!

With these changes, things get substantially better!
```
pkg: github.com/bitly/go-hostpool
BenchmarkEpsilonGreedy
BenchmarkEpsilonGreedy-8            	 2128981	       559 ns/op	     104 B/op	       2 allocs/op
BenchmarkEpsilonGreedyManyHosts
BenchmarkEpsilonGreedyManyHosts/Hosts10
BenchmarkEpsilonGreedyManyHosts/Hosts10-8         	 1425793	       768 ns/op	     104 B/op	       2 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts25
BenchmarkEpsilonGreedyManyHosts/Hosts25-8         	 1000000	      1115 ns/op	     104 B/op	       2 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts50
BenchmarkEpsilonGreedyManyHosts/Hosts50-8         	  739261	      1719 ns/op	     104 B/op	       2 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts100
BenchmarkEpsilonGreedyManyHosts/Hosts100-8        	  474729	      3141 ns/op	     104 B/op	       2 allocs/op
BenchmarkEpsilonGreedyManyHosts/Hosts250
BenchmarkEpsilonGreedyManyHosts/Hosts250-8        	  246646	      6379 ns/op	     104 B/op	       2 allocs/op
```

That's a 30x to 50x improvement by being a bit more intelligent!