### PR TITLE
Update module path to hailocab/go-hostpool

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -1,7 +1,7 @@
 package hostpool
 
 import (
-	"github.com/bitly/go-hostpool"
+	"github.com/hailocab/go-hostpool"
 )
 
 func ExampleNewEpsilonGreedy() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bitly/go-hostpool
+module github.com/hailocab/go-hostpool
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hailocab/go-hostpool
 
 go 1.15
 
-require github.com/stretchr/testify v1.5.1
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This is a fork of a fork, and having the fork declare the module path of the 'grandparent' leads to issues when subsequent imports of both the parent and then child modules as transitive dependencies are both imported. Go module's `replace` doesn't seem to be able to cope with this. 

By declaring this as `hailocab/go-hostpool`, we can make all interal imports use `monzo/go-hostpool` and use a `replace` directive to cover the transitive dependency for `hailocab/`. Hopefully.