### PR TITLE
Configure standard hostpool with max failure percentage

### DIFF
--- a/host_entry.go
+++ b/host_entry.go
@@ -13,6 +13,7 @@ type hostEntry struct {
 	retryDelay time.Duration
 	dead       bool
 	failures   *ringBuffer
+	successes  *ringBuffer
 
 	epsilonCounts          []int64 // ring of counts observed
 	epsilonValues          []int64 // ring of total time observations observed

--- a/standard_hostpool.go
+++ b/standard_hostpool.go
@@ -245,7 +245,9 @@ func (p *standardHostPool) markSuccess(hostR HostPoolResponse) {
 		p.logger.Fatalf("host %s not in HostPool %v", host, p.Hosts())
 	}
 	h.dead = false
-	h.successes.insert(time.Now())
+	if h.successes != nil {
+		h.successes.insert(time.Now())
+	}
 }
 
 func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
@@ -271,7 +273,7 @@ func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
 
 			successesInWindow := h.successes.since(ts.Add(failureLookback))
 			failurePercent := (float64(failuresInWindow) / float64(failuresInWindow+successesInWindow)) * 100
-			if failurePercent >= p.maxFailurePercent {
+			if failurePercent >= p.maxFailurePercent && successesInWindow > 0 {
 				log.Printf("host %s exceeded %f%% failure percent in %s", h.host, p.maxFailurePercent, p.failureWindow)
 				h.markDead(p.initialRetryDelay)
 				return

--- a/standard_hostpool.go
+++ b/standard_hostpool.go
@@ -273,6 +273,7 @@ func (p *standardHostPool) markFailed(hostR HostPoolResponse) {
 
 			successesInWindow := h.successes.since(ts.Add(failureLookback))
 			failurePercent := (float64(failuresInWindow) / float64(failuresInWindow+successesInWindow)) * 100
+			// Check that we've had at least one success, otherwise a single error would mark a host as down
 			if failurePercent >= p.maxFailurePercent && successesInWindow > 0 {
 				log.Printf("host %s exceeded %f%% failure percent in %s", h.host, p.maxFailurePercent, p.failureWindow)
 				h.markDead(p.initialRetryDelay)


### PR DESCRIPTION
Currently the standard hostpool is configured to mark a host as down after it exceeds a fixed number of errors. For low throughput uses even if a host is permanently down we might never hit that threshold - for example if the hostpool is configured with maxFailures: 10, failureWindow: 10s but the service only does 5 requests in 10 seconds then a bad host will never get marked as down.

This PR provides an additional configuration option to set a maxFailurePercentage, so the host will be marked as down if a certain % of requests have failed, or if >maxFailures requests have failed.

The default for maxFailurePercentage is set to 101% so if it isn't explicitly set the behavior is identical to before.