### PR TITLE
Allow passing custom logger interface

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,23 @@
+package hostpool
+
+import "log"
+
+type Logger interface {
+	Printf(msg string, params ...interface{})
+	Println(msg string)
+	Fatalf(msg string, params ...interface{})
+}
+
+type DefaultLogger struct{}
+
+func (l DefaultLogger) Printf(msg string, params ...interface{}) {
+	log.Printf(msg, params...)
+}
+
+func (l DefaultLogger) Println(msg string) {
+	log.Println(msg)
+}
+
+func (l DefaultLogger) Fatalf(msg string, params ...interface{}) {
+	log.Fatalf(msg, params...)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,43 @@
+package hostpool
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testFakeLogger struct {
+	callCount int
+}
+
+func (l *testFakeLogger) Printf(msg string, args ...interface{}) {
+	l.callCount += 1
+}
+
+func (l *testFakeLogger) Println(msg string) {
+	l.callCount += 1
+}
+
+func (l *testFakeLogger) Fatalf(msg string, args ...interface{}) {
+	l.callCount += 1
+}
+
+func TestLogger(t *testing.T) {
+	dummyErr := errors.New("Dummy Error")
+	lgr := testFakeLogger{}
+
+	p := NewWithOptions([]string{"a"}, StandardHostPoolOptions{
+		MaxFailures:   1,
+		FailureWindow: 60 * time.Second,
+		Logger:        &lgr,
+	})
+
+	// Mark two errors against a.
+	p.Get().Mark(dummyErr)
+	p.Get().Mark(dummyErr)
+
+	// we should have logged an error
+	assert.Equal(t, lgr.callCount, 1)
+}


### PR DESCRIPTION
Currently all logs go to the standard go `log` package.

This PR allows passing a logger interface to send logs to a custom logging library