### PR TITLE
Lock on closing hostpool to avoid race with statistics

### DIFF
--- a/standard_hostpool.go
+++ b/standard_hostpool.go
@@ -221,6 +221,8 @@ func (p *standardHostPool) doResetAll() {
 }
 
 func (p *standardHostPool) Close() {
+	p.Lock()
+	defer p.Unlock()
 	for _, h := range p.hosts {
 		h.dead = true
 	}


### PR DESCRIPTION
Acquire the lock in `.Close` to avoid a data race when [we read `h.dead` in `.Statistics`](https://github.com/monzo/go-hostpool/blob/master/standard_hostpool.go#L279).

[Fixes flakey test](https://monzo.slack.com/archives/C02M7EUUV32/p1713590467379809)